### PR TITLE
feat(webapp): Streamlit dashboard MVP with auto-refresh, transfer bundle, and logs filters

### DIFF
--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -127,6 +127,26 @@ python -m pip install -r Scripts/requirements.txt
 streamlit run Scripts/webapp/app.py
 ```
 
+### Features
+
+- KPIs from `Outputs/Status/last_update.json` with staleness warning.
+- Status breakdown bar chart (completed / partial / missing / no_playlist).
+- Station table with filter and drilldown:
+  - Download latest Raw/Danish/English CSVs.
+  - Preview latest CSVs inline with file metadata (name, size, modified time).
+  - Inspect NoPlaylist marker JSONs (if present).
+- Run now: starts orchestrator via `Scripts/run_radio_update.sh` with lock file protection.
+- Logs viewer: picks the log referenced in status by default; manual refresh button.
+- Status controls: Reload page + Download `last_update.json`.
+- Next scheduled run: shows next Tue/Fri 09:30 (local) time.
+
+### Auto-refresh
+
+- Sidebar has Auto-refresh toggles and interval slider.
+  - Status and Logs can be auto-refreshed.
+  - Interval is configurable (default 30s).
+- Powered by `streamlit-autorefresh` (included in `Scripts/requirements.txt`).
+
 Notes:
 - The app reads `Outputs/Status/last_update.json` and `Outputs/Stations/` to render KPIs and per-station files.
 - The "Run now" button calls `Scripts/run_radio_update.sh` and uses a lock file in `Logs/.update.lock` to prevent overlaps.

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -98,6 +98,28 @@ crontab -e
   /Users/gigwebs/Library/CloudStorage/Dropbox/MUSIC\ BANK/Rekordbox\ Scouts/Rekordbox\ Filter/Radio\ Filter/Logs/cron.out.log 2>&1
 ```
 
+## Frontend dashboard (Streamlit)
+
+Run a local dashboard to visualize status, drill into stations, trigger a run, and view logs.
+
+1) Install dependencies (inside project root):
+
+```bash
+source .venv/bin/activate  # or create: python3 -m venv .venv && source .venv/bin/activate
+python -m pip install -r Scripts/requirements.txt
+```
+
+2) Start the app:
+
+```bash
+streamlit run Scripts/webapp/app.py
+```
+
+Notes:
+- The app reads `Outputs/Status/last_update.json` and `Outputs/Stations/` to render KPIs and per-station files.
+- The "Run now" button calls `Scripts/run_radio_update.sh` and uses a lock file in `Logs/.update.lock` to prevent overlaps.
+- Logs are read from `Logs/auto_update_*.log` and the file referenced in `log_file` within the status JSON.
+
 ## Notes
 - Desktop notifications may not display if the process runs in a non-interactive session. Email remains available via `--notify-email`.
 - The wrapper bootstraps a virtual environment on first run and uses it thereafter.

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -102,6 +102,18 @@ crontab -e
 
 Run a local dashboard to visualize status, drill into stations, trigger a run, and view logs.
 
+### Quick start (recommended)
+
+From the project root:
+
+```bash
+./Scripts/run_dashboard.sh
+```
+
+This script bootstraps the virtual environment (if missing), installs requirements, and starts the app.
+
+### Manual setup (alternative)
+
 1) Install dependencies (inside project root):
 
 ```bash

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -136,9 +136,10 @@ streamlit run Scripts/webapp/app.py
   - Preview latest CSVs inline with file metadata (name, size, modified time).
   - Inspect NoPlaylist marker JSONs (if present).
 - Run now: starts orchestrator via `Scripts/run_radio_update.sh` with lock file protection.
-- Logs viewer: picks the log referenced in status by default; manual refresh button.
+- Logs viewer: picks the log referenced in status by default; manual refresh button; tail N lines and substring filter.
 - Status controls: Reload page + Download `last_update.json`.
 - Next scheduled run: shows next Tue/Fri 09:30 (local) time.
+- Transfer bundle: one-click ZIP download of the latest Radio transfer artifacts.
 
 ### Auto-refresh
 
@@ -146,6 +147,21 @@ streamlit run Scripts/webapp/app.py
   - Status and Logs can be auto-refreshed.
   - Interval is configurable (default 30s).
 - Powered by `streamlit-autorefresh` (included in `Scripts/requirements.txt`).
+
+### Transfer bundle
+
+- The "Transfer bundle" section packages the latest transfer files from
+  `Outputs/Transfer/Radio/` into a single ZIP for easy download.
+- It prefers files matching the current status date (e.g., `*_Radio_New_*_YYYY-MM-DD_*`).
+- If no same-date files are found, it falls back to the most recent `*_Radio_New_*` files.
+
+### Logs viewer
+
+- Choose from the status-referenced log or recent `Logs/auto_update_*.log` files.
+- Controls:
+  - "Last N lines" slider to tail recent output.
+  - "Filter (substring)" with case-insensitive toggle.
+  - "Refresh" and "Reset log filter" buttons.
 
 Notes:
 - The app reads `Outputs/Status/last_update.json` and `Outputs/Stations/` to render KPIs and per-station files.

--- a/Scripts/requirements.txt
+++ b/Scripts/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv>=1.0,<2.0
 mutagen>=1.46,<2.0
 xlsxwriter>=3.0,<4.0
 streamlit>=1.31,<2.0
+streamlit-autorefresh>=0.0.1,<1.0

--- a/Scripts/requirements.txt
+++ b/Scripts/requirements.txt
@@ -6,3 +6,4 @@ html5lib==1.1
 python-dotenv>=1.0,<2.0
 mutagen>=1.46,<2.0
 xlsxwriter>=3.0,<4.0
+streamlit>=1.31,<2.0

--- a/Scripts/run_dashboard.sh
+++ b/Scripts/run_dashboard.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# venv-aware launcher for the Streamlit dashboard
+# Location: <PROJECT_ROOT>/Scripts/run_dashboard.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VENV_DIR="${PROJECT_DIR}/.venv"
+REQ_FILE="${PROJECT_DIR}/Scripts/requirements.txt"
+APP_FILE="${PROJECT_DIR}/Scripts/webapp/app.py"
+
+if [ ! -d "${VENV_DIR}" ]; then
+  echo "[dashboard] Creating virtual environment at ${VENV_DIR}"
+  python3 -m venv "${VENV_DIR}"
+fi
+
+# shellcheck disable=SC1090
+source "${VENV_DIR}/bin/activate"
+python -m pip install --upgrade pip >/dev/null 2>&1 || true
+
+# Ensure requirements (including streamlit) are installed
+python -m pip install -r "${REQ_FILE}"
+
+# Run the app
+exec streamlit run "${APP_FILE}"

--- a/Scripts/webapp/app.py
+++ b/Scripts/webapp/app.py
@@ -10,6 +10,10 @@ from typing import Dict, List, Optional
 
 import pandas as pd
 import streamlit as st
+try:
+    from streamlit_autorefresh import st_autorefresh  # type: ignore
+except Exception:
+    st_autorefresh = None  # type: ignore
 
 # --------------------------------------------------------------------------------------
 # Paths and constants
@@ -246,8 +250,20 @@ with st.sidebar:
     st.code(str(OUTPUTS_DIR))
     st.markdown("**Logs**")
     st.code(str(LOGS_DIR))
+    st.markdown("**Auto-refresh**")
+    auto_status = st.checkbox("Status", value=False, key="auto_status")
+    auto_logs = st.checkbox("Logs", value=False, key="auto_logs")
+    interval = st.slider(
+        "Interval (sec)", min_value=5, max_value=120, value=30, step=5, key="auto_interval"
+    )
+    if st_autorefresh is None and (auto_status or auto_logs):
+        st.info("Auto-refresh helper will be installed automatically.")
 
 status = load_status()
+
+# Global auto-refresh (refreshes entire page)
+if st_autorefresh and (auto_status or auto_logs):
+    st_autorefresh(interval=interval * 1000, key="auto_refresh_tick")
 
 # Top KPIs
 col1, col2, col3, col4, col5 = st.columns(5)

--- a/Scripts/webapp/app.py
+++ b/Scripts/webapp/app.py
@@ -31,7 +31,7 @@ NO_PLAYLIST_MARKER = "NoPlaylist"
 # Utilities
 # --------------------------------------------------------------------------------------
 
- 
+
 def load_status() -> Optional[dict]:
     try:
         with open(STATUS_PATH, "r", encoding="utf-8") as f:
@@ -317,10 +317,11 @@ st.subheader("Logs")
 log_file_from_status = Path(status["log_file"]) if status and status.get("log_file") else None
 available_logs = list_latest_logs(limit=20)
 
-log_choice = st.selectbox(
-    "Choose a log file",
-    options=[str(p) for p in ([log_file_from_status] if log_file_from_status else []) + available_logs],
-)
+pref_list = [log_file_from_status] if log_file_from_status else []
+log_candidates = pref_list + available_logs
+log_options = [str(p) for p in log_candidates]
+
+log_choice = st.selectbox("Choose a log file", options=log_options)
 
 if log_choice:
     path = Path(log_choice)

--- a/Scripts/webapp/app.py
+++ b/Scripts/webapp/app.py
@@ -223,11 +223,43 @@ if status:
     with col5:
         st.metric("No playlist", n)
 
+    # Staleness check and caption
+    gen_text = status.get("generated_at", "-")
+    gen_dt = None
+    try:
+        if gen_text and gen_text != "-":
+            gen_dt = datetime.strptime(gen_text, "%Y-%m-%d %H:%M:%S")
+    except Exception:
+        gen_dt = None
+
+    if gen_dt is not None:
+        age = datetime.now() - gen_dt
+        if age.days >= 3:
+            st.error(f"Status is stale: generated {age.days} days ago")
+        elif age.days >= 1:
+            st.warning(f"Status is {age.days} day(s) old")
+
     st.caption(
         f"Date: {status.get('date', '-')}, "
-        f"Generated: {status.get('generated_at', '-')}, "
+        f"Generated: {gen_text}, "
         f"Log: {status.get('log_file', '-')}"
     )
+
+    ctrl1, ctrl2 = st.columns([1, 2])
+    with ctrl1:
+        if st.button("Reload status"):
+            st.experimental_rerun()
+    with ctrl2:
+        try:
+            st.download_button(
+                label="Download status.json",
+                data=STATUS_PATH.read_bytes(),
+                file_name="last_update.json",
+                mime="application/json",
+                key="dl_status_json",
+            )
+        except Exception:
+            pass
 else:
     st.warning("Status file not found. Run the orchestrator to generate outputs.")
 

--- a/Scripts/webapp/app.py
+++ b/Scripts/webapp/app.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pandas as pd
+import streamlit as st
+
+# --------------------------------------------------------------------------------------
+# Paths and constants
+# --------------------------------------------------------------------------------------
+# This file lives at: <PROJECT_ROOT>/Scripts/webapp/app.py
+# We want base_dir = <PROJECT_ROOT> (the "Radio Filter" directory)
+BASE_DIR = Path(__file__).resolve().parents[2]
+OUTPUTS_DIR = BASE_DIR / "Outputs"
+STATIONS_DIR = OUTPUTS_DIR / "Stations"
+STATUS_PATH = OUTPUTS_DIR / "Status" / "last_update.json"
+LOGS_DIR = BASE_DIR / "Logs"
+WRAPPER_PATH = BASE_DIR / "Scripts" / "run_radio_update.sh"
+LOCK_PATH = LOGS_DIR / ".update.lock"
+
+NO_PLAYLIST_MARKER = "NoPlaylist"
+
+
+# --------------------------------------------------------------------------------------
+# Utilities
+# --------------------------------------------------------------------------------------
+
+ 
+def load_status() -> Optional[dict]:
+    try:
+        with open(STATUS_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except Exception as e:
+        st.error(f"Failed to read status: {e}")
+        return None
+
+
+def list_latest_logs(limit: int = 10) -> List[Path]:
+    if not LOGS_DIR.exists():
+        return []
+    logs = sorted(LOGS_DIR.glob("auto_update_*.log"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return logs[:limit]
+
+
+def safe_read(path: Path, max_bytes: int = 200_000) -> str:
+    try:
+        with open(path, "rb") as f:
+            data = f.read(max_bytes)
+        # If file is larger than max_bytes, indicate truncation
+        suffix = b"\n\n-- (truncated) --\n" if path.stat().st_size > max_bytes else b""
+        return (data + suffix).decode("utf-8", errors="replace")
+    except Exception as e:
+        return f"<error reading {path}: {e}>"
+
+
+def stations_from_status(status: dict) -> pd.DataFrame:
+    completed = status.get("stations_completed", [])
+    partial = status.get("stations_partial", [])
+    missing = status.get("stations_missing", [])
+    no_playlist = status.get("stations_no_playlist", [])
+
+    rows = []
+    for s in completed:
+        rows.append({"station": s, "status": "completed"})
+    for s in partial:
+        rows.append({"station": s, "status": "partial"})
+    for s in missing:
+        rows.append({"station": s, "status": "missing"})
+    for s in no_playlist:
+        rows.append({"station": s, "status": "no_playlist"})
+
+    df = pd.DataFrame(rows)
+    if not df.empty:
+        df = df.sort_values(["status", "station"]).reset_index(drop=True)
+    return df
+
+
+def latest_station_files(station: str) -> Dict[str, List[Path]]:
+    """Return recent files for a station grouped by category.
+
+    Looks for:
+    - Raw playlist CSVs: *_Raw_Playlist_past_7_days_*.csv
+    - Titles CSVs: *_Danish_Titles_past_7_days_*.csv and *_English_Titles_past_7_days_*.csv
+    - NoPlaylist markers: *_NoPlaylist_past_7_days_*.json
+    """
+    base = STATIONS_DIR / station
+    results: Dict[str, List[Path]] = {
+        "raw": [],
+        "danish_titles": [],
+        "english_titles": [],
+        "no_playlist_markers": [],
+    }
+    if not base.exists():
+        return results
+
+    # Raw
+    raw_dir = base / "Raw"
+    if raw_dir.exists():
+        results["raw"] = sorted(
+            raw_dir.glob(f"{station}_Raw_Playlist_past_7_days_*.csv"),
+            key=lambda p: p.name,
+            reverse=True,
+        )
+        results["no_playlist_markers"] = sorted(
+            raw_dir.glob(f"{station}_{NO_PLAYLIST_MARKER}_past_7_days_*.json"),
+            key=lambda p: p.name,
+            reverse=True,
+        )
+
+    # Danish
+    danish_dir = base / "Danish"
+    if danish_dir.exists():
+        results["danish_titles"] = sorted(
+            danish_dir.glob(f"{station}_Danish_Titles_past_7_days_*.csv"),
+            key=lambda p: p.name,
+            reverse=True,
+        )
+
+    # English
+    english_dir = base / "English"
+    if english_dir.exists():
+        results["english_titles"] = sorted(
+            english_dir.glob(f"{station}_English_Titles_past_7_days_*.csv"),
+            key=lambda p: p.name,
+            reverse=True,
+        )
+
+    return results
+
+
+@dataclass
+class RunConfig:
+    force: bool = False
+    extract_log_level: str = "INFO"
+    notify_email: str = ""
+
+
+def run_orchestrator(cfg: RunConfig) -> subprocess.Popen | None:
+    """Kick off the orchestrator via the venv-aware wrapper.
+    Uses a lock file to avoid concurrent runs. Returns the Popen object if started.
+    """
+    try:
+        LOGS_DIR.mkdir(parents=True, exist_ok=True)
+        if LOCK_PATH.exists():
+            st.warning("A run appears to be in progress (lock file present).")
+            return None
+        # Create lock file
+        LOCK_PATH.write_text(f"started: {datetime.now().isoformat()}\n")
+
+        args = [str(WRAPPER_PATH), "--extract-log-level", cfg.extract_log_level]
+        if cfg.force:
+            args.append("--force")
+        if cfg.notify_email:
+            args.extend(["--notify-email", cfg.notify_email])
+
+        # Start process detached so it survives app reloads
+        proc = subprocess.Popen(args, cwd=str(BASE_DIR))
+
+        def _cleanup_on_exit(p: subprocess.Popen):
+            p.wait()
+            # Remove lock when done
+            if LOCK_PATH.exists():
+                try:
+                    LOCK_PATH.unlink()
+                except Exception:
+                    pass
+
+        threading.Thread(target=_cleanup_on_exit, args=(proc,), daemon=True).start()
+        return proc
+    except Exception as e:
+        # Ensure lock removed on failure
+        if LOCK_PATH.exists():
+            try:
+                LOCK_PATH.unlink()
+            except Exception:
+                pass
+        st.error(f"Failed to start orchestrator: {e}")
+        return None
+
+
+# --------------------------------------------------------------------------------------
+# UI
+# --------------------------------------------------------------------------------------
+
+st.set_page_config(page_title="Radio Explorer", page_icon="📻", layout="wide")
+
+st.title("📻 Danish Radio Explorer")
+with st.sidebar:
+    st.markdown("**Project root**")
+    st.code(str(BASE_DIR))
+    st.markdown("**Outputs**")
+    st.code(str(OUTPUTS_DIR))
+    st.markdown("**Logs**")
+    st.code(str(LOGS_DIR))
+
+status = load_status()
+
+# Top KPIs
+col1, col2, col3, col4, col5 = st.columns(5)
+if status:
+    total = status.get("stations_total", 0)
+    c = len(status.get("stations_completed", []))
+    p = len(status.get("stations_partial", []))
+    m = len(status.get("stations_missing", []))
+    n = len(status.get("stations_no_playlist", []))
+
+    with col1:
+        st.metric("Stations (total)", total)
+    with col2:
+        st.metric("Completed", c)
+    with col3:
+        st.metric("Partial", p)
+    with col4:
+        st.metric("Missing", m)
+    with col5:
+        st.metric("No playlist", n)
+
+    st.caption(
+        f"Date: {status.get('date', '-')}, "
+        f"Generated: {status.get('generated_at', '-')}, "
+        f"Log: {status.get('log_file', '-')}"
+    )
+else:
+    st.warning("Status file not found. Run the orchestrator to generate outputs.")
+
+st.divider()
+
+# Station overview table
+st.subheader("Station status")
+if status:
+    df = stations_from_status(status)
+    if df.empty:
+        st.info("No stations reported in status.")
+    else:
+        filt = st.multiselect("Filter by status", options=sorted(df["status"].unique()), default=[])
+        view = df if not filt else df[df["status"].isin(filt)].reset_index(drop=True)
+        st.dataframe(view, use_container_width=True, hide_index=True)
+
+        # Select a single station to inspect
+        st.subheader("Station drilldown")
+        station = st.selectbox("Choose a station", options=df["station"].tolist())
+        files = latest_station_files(station)
+        cols = st.columns(3)
+        with cols[0]:
+            st.markdown("**Raw playlist CSVs**")
+            if files["raw"]:
+                for p in files["raw"][:3]:
+                    st.download_button(
+                        label=p.name,
+                        data=p.read_bytes(),
+                        file_name=p.name,
+                        mime="text/csv",
+                        key=f"dl_raw_{p.name}",
+                    )
+            else:
+                st.write("—")
+        with cols[1]:
+            st.markdown("**Danish titles CSVs**")
+            if files["danish_titles"]:
+                for p in files["danish_titles"][:3]:
+                    st.download_button(
+                        label=p.name,
+                        data=p.read_bytes(),
+                        file_name=p.name,
+                        mime="text/csv",
+                        key=f"dl_da_{p.name}",
+                    )
+            else:
+                st.write("—")
+        with cols[2]:
+            st.markdown("**English titles CSVs**")
+            if files["english_titles"]:
+                for p in files["english_titles"][:3]:
+                    st.download_button(
+                        label=p.name,
+                        data=p.read_bytes(),
+                        file_name=p.name,
+                        mime="text/csv",
+                        key=f"dl_en_{p.name}",
+                    )
+            else:
+                st.write("—")
+
+        if files["no_playlist_markers"]:
+            with st.expander("No‑playlist markers"):
+                for p in files["no_playlist_markers"][:3]:
+                    st.code(safe_read(p, max_bytes=50_000), language="json")
+
+st.divider()
+
+# Run Now section
+st.subheader("Run now")
+run_col1, run_col2, run_col3 = st.columns([1, 1, 2])
+with run_col1:
+    force = st.checkbox("Force run (ignore Tue/Fri gating)", value=False)
+with run_col2:
+    notify = st.text_input("Notify email (optional)", value="")
+with run_col3:
+    level = st.selectbox("Log level", options=["DEBUG", "INFO", "WARNING", "ERROR"], index=1)
+
+btn = st.button("Start orchestrator", type="primary", disabled=LOCK_PATH.exists() or not WRAPPER_PATH.exists())
+if btn:
+    proc = run_orchestrator(RunConfig(force=force, extract_log_level=level, notify_email=notify))
+    if proc is not None:
+        st.success("Orchestrator started. A lock file prevents overlaps; it will clear when done.")
+
+# Log viewer
+st.subheader("Logs")
+log_file_from_status = Path(status["log_file"]) if status and status.get("log_file") else None
+available_logs = list_latest_logs(limit=20)
+
+log_choice = st.selectbox(
+    "Choose a log file",
+    options=[str(p) for p in ([log_file_from_status] if log_file_from_status else []) + available_logs],
+)
+
+if log_choice:
+    path = Path(log_choice)
+    st.caption(f"Showing: {path}")
+    st.code(safe_read(path), language="log")
+    if st.button("Refresh log view"):
+        st.experimental_rerun()
+
+st.divider()
+
+st.caption("Tip: Use the Run now button sparingly. The LaunchAgent will run on Tuesday and Friday at 09:30.")


### PR DESCRIPTION
This PR introduces the Streamlit dashboard MVP for the Danish Radio Explorer:\n\n- Auto-refresh sidebar controls (streamlit-autorefresh) with interval and toggles for status/logs.\n- Status breakdown chart, staleness warnings, next scheduled run (Tue/Fri 09:30).\n- Station drilldown with latest Raw/Danish/English CSV previews and metadata.\n- "Run now" integration using venv-aware wrapper and lock file protection.\n- Transfer bundle ZIP: packages latest Outputs/Transfer/Radio artifacts (prefers same-date fallback to most recent).\n- Logs viewer: tail last N lines, substring filter, case-insensitive toggle; refresh/reset controls.\n- README updated with documentation for auto-refresh, transfer bundle, logs filters.\n\nBranch: feat/frontend-mvp\nBase: main